### PR TITLE
Add missing <string> and <memory> includes

### DIFF
--- a/GlitterStudio/FileDialog.h
+++ b/GlitterStudio/FileDialog.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <unordered_map>
 #include <array>
-
+#include <string>
 namespace Glitter
 {
 	namespace Editor

--- a/GlitterStudio/PropertyCommands.h
+++ b/GlitterStudio/PropertyCommands.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "ICommand.h"
 #include <functional>
-
+#include <memory>
 namespace Glitter
 {
 	namespace Editor


### PR DESCRIPTION
In modern MSVC, We need to make sure standard types used in those headers are available and to preven compilation errors.